### PR TITLE
change info! messages to debug! messages

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -219,7 +219,7 @@ impl<'a> Reader<'a> {
             data_size -= delta_time.len() as u32;
             let mut status = self.file.read_u8()?;
             if status < 0b10000000 {
-                info!(
+                debug!(
                     "running status has found! recorded data: {}, corrected data: {}",
                     status, pre_status
                 );
@@ -231,7 +231,7 @@ impl<'a> Reader<'a> {
             match status {
                 0xff => {
                     // meta event
-                    info!("meta event status has found!");
+                    debug!("meta event status has found!");
                     let meta_event = MetaEvent::new(self.file.read_u8()?);
                     data_size -= mem::size_of::<u8>() as u32;
                     let len = self.read_vlq()?;
@@ -245,7 +245,7 @@ impl<'a> Reader<'a> {
                 }
                 0x80...0xef => {
                     // midi event
-                    info!("midi event status has found!");
+                    debug!("midi event status has found!");
                     let mut builder = MidiEventBuilder::new(status);
                     while builder.shortage() > 0 {
                         builder.push(self.file.read_u8()?);
@@ -261,7 +261,7 @@ impl<'a> Reader<'a> {
                 }
                 0xf0 | 0xf7 => {
                     // system exclusive event
-                    info!("system exclusice event status has found!");
+                    debug!("system exclusice event status has found!");
                     if status == 0xf7 && pre_status == 0xf0 {
                         pre_status = 0;
                         data_size -= mem::size_of::<u8>() as u32;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -280,7 +280,7 @@ impl<'a> Writer<'a> {
                         }
                         _ => {
                             file.write(&message.binary())?;
-                            debug!("wrote some message");
+                            trace!("wrote some message");
                             if self.running_status {
                                 pre_status_byte = Some(tmp_status_byte);
                             }
@@ -289,7 +289,7 @@ impl<'a> Writer<'a> {
                 }
                 _ => {
                     file.write(&message.binary())?;
-                    debug!("wrote some message");
+                    trace!("wrote some message");
                 }
             }
         }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -276,7 +276,7 @@ impl<'a> Writer<'a> {
                             let tmp_message = message.binary();
                             file.write(&tmp_message[0..delta_time.len()])?;
                             file.write(&message.binary()[delta_time.len() + 1..])?;
-                            debug!("wrote some message with running status");
+                            trace!("wrote some message with running status");
                         }
                         _ => {
                             file.write(&message.binary())?;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -237,7 +237,7 @@ impl<'a> Writer<'a> {
     /// writer.write(&path);
     /// ```
     pub fn write(&self, path: &path::Path) -> Result<(), io::Error> {
-        info!("start writing at {:?}", path);
+        debug!("start writing at {:?}", path);
         let mut file = io::BufWriter::new(
             fs::OpenOptions::new()
                 .write(true)
@@ -262,7 +262,7 @@ impl<'a> Writer<'a> {
                     file.write(&Message::TrackChange.binary())?;
                     file.write_u32::<BigEndian>(track_len_filo.pop().unwrap() as u32)?;
                     pre_status_byte = None;
-                    info!("wrote track change");
+                    debug!("wrote track change");
                 }
                 Message::MidiEvent {
                     delta_time,
@@ -276,11 +276,11 @@ impl<'a> Writer<'a> {
                             let tmp_message = message.binary();
                             file.write(&tmp_message[0..delta_time.len()])?;
                             file.write(&message.binary()[delta_time.len() + 1..])?;
-                            info!("wrote some message with running status");
+                            debug!("wrote some message with running status");
                         }
                         _ => {
                             file.write(&message.binary())?;
-                            info!("wrote some message");
+                            debug!("wrote some message");
                             if self.running_status {
                                 pre_status_byte = Some(tmp_status_byte);
                             }
@@ -289,7 +289,7 @@ impl<'a> Writer<'a> {
                 }
                 _ => {
                     file.write(&message.binary())?;
-                    info!("wrote some message");
+                    debug!("wrote some message");
                 }
             }
         }


### PR DESCRIPTION
I want to generate SMF data at runtime, the default log behavior was producing a bit too many messages at info! level.