### PR TITLE
add blank impl Error for ReadError

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2,7 +2,7 @@ use byteorder::{BigEndian, ReadBytesExt};
 use formats::*;
 use messages::*;
 use std::io::{Read, Seek, SeekFrom};
-use std::{fmt, fs, io, mem, path};
+use std::{error, fmt, fs, io, mem, path};
 
 /// `ghakuf`'s SMF parser.
 ///
@@ -461,6 +461,7 @@ impl<'a> fmt::Display for ReadError<'a> {
         }
     }
 }
+impl<'a> error::Error for ReadError<'a> {}
 impl<'a> From<io::Error> for ReadError<'a> {
     fn from(err: io::Error) -> ReadError<'a> {
         ReadError::Io(err)


### PR DESCRIPTION
Hi.

Thanks for the awesome library.

I have only one problem with it - `ReadError` doesn't implement `std::error::Error`, so I can't use `?` if my function returns `anyhow::Error` or `Box<std::error::Error>`.

I noticed, that `impl Error` was removed recently as deprecated in 4b804d1ec0df433ccb406d6d3dff3f599000ebac. But I guess it was removed as a whole by mistake. It is still recommended implementing `std::error::Error` for error types and only implementing `description` was deprecated in favor of Debug+Display.